### PR TITLE
Platform Compatibility changes to quest_lib and http_lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,2 @@
-build/CMakeCache.txt
-build/.cmake/api/v1/query/client-vscode/query.json
-build/CMakeFiles/cmake.check_cache
-build/CMakeFiles/CMakeConfigureLog.yaml
-build/CMakeFiles/3.30.1/CMakeSystem.cmake
-build/CMakeFiles/3.30.1/CompilerIdC/CMakeCCompilerId.c
-build/CMakeFiles/3.30.1/CompilerIdC/CMakeCCompilerId.o
-build/CMakeFiles/3.30.1/CompilerIdCXX/CMakeCXXCompilerId.cpp
-build/CMakeFiles/3.30.1/CompilerIdCXX/CMakeCXXCompilerId.o
+build/
 .vscode/

--- a/common/include/networking.h
+++ b/common/include/networking.h
@@ -62,10 +62,10 @@ int setblocking(int fd, bool val);
 int create_socketpair(int socket_pair[2]);
 
 /* Lookup the provided outgoing destination and fill the linked-list accordingly. */
-int address_lookup_client(char const* dest, uint16_t port, struct addrinfo** addr);
+int address_lookup_client(char const* dest, uint16_t port, struct addrinfo** addr, int family);
 
 /* Lookup the provided incoming destination and fill the linked-list accordingly. */
-int address_lookup_server(char const* dest, uint16_t port, struct addrinfo** addr);
+int address_lookup_server(char const* dest, uint16_t port, struct addrinfo** addr, int family);
 
 /* Create a new listening socket for given type and address.
  *

--- a/common/src/networking.c
+++ b/common/src/networking.c
@@ -860,9 +860,9 @@ int create_socketpair(int socket_pair[2])
 #endif
 }
 
-static int address_lookup_internal(char const* dest, uint16_t port, struct addrinfo** addr, int flags)
+static int address_lookup_internal(char const* dest, uint16_t port, struct addrinfo** addr, int family, int flags)
 {
-        struct addrinfo hints = {.ai_family = AF_UNSPEC,
+        struct addrinfo hints = {.ai_family = family,
                                  .ai_socktype = SOCK_STREAM,
                                  .ai_protocol = IPPROTO_TCP,
                                  .ai_flags = flags};
@@ -891,15 +891,15 @@ static int address_lookup_internal(char const* dest, uint16_t port, struct addri
 }
 
 /* Lookup the provided outgoing destination and fill the linked-list accordingly. */
-int address_lookup_client(char const* dest, uint16_t port, struct addrinfo** addr)
+int address_lookup_client(char const* dest, uint16_t port, struct addrinfo** addr, int family)
 {
-        return address_lookup_internal(dest, port, addr, AI_NUMERICSERV | AI_ADDRCONFIG);
+        return address_lookup_internal(dest, port, addr, family, AI_NUMERICSERV | AI_ADDRCONFIG);
 }
 
 /* Lookup the provided incoming destination and fill the linked-list accordingly. */
-int address_lookup_server(char const* dest, uint16_t port, struct addrinfo** addr)
+int address_lookup_server(char const* dest, uint16_t port, struct addrinfo** addr, int family)
 {
-        return address_lookup_internal(dest, port, addr, AI_PASSIVE | AI_NUMERICSERV | AI_ADDRCONFIG);
+        return address_lookup_internal(dest, port, addr, family, AI_PASSIVE | AI_NUMERICSERV | AI_ADDRCONFIG);
 }
 
 /* Create a new listening socket for given type and address.

--- a/echo_server/src/echo_server.c
+++ b/echo_server/src/echo_server.c
@@ -377,7 +377,7 @@ static int prepare_server(echo_server* server, echo_server_config const* config)
          * Do a DNS lookup to make sure we have an IP address. If we already have an IP, this
          * results in a noop. */
         struct addrinfo* bind_addr = NULL;
-        ret = address_lookup_server(config->own_ip_address, config->listening_port, &bind_addr);
+        ret = address_lookup_server(config->own_ip_address, config->listening_port, &bind_addr, AF_UNSPEC);
         if (ret < 0)
                 ERROR_OUT("Error looking up target IP address");
 

--- a/http_lib/include/http_client.h
+++ b/http_lib/include/http_client.h
@@ -32,11 +32,9 @@
 #if defined(__ZEPHYR__)
 #include <zephyr/kernel.h>
 #include <zephyr/net/net_ip.h>
-k_timeout_t
 #define AT_LEAST MIN
 #else
 #define AT_LEAST(a, b) (((a) < (b)) ? (a) : (b))
-#include "linux_comp.h"
 #endif // __ZEPHYR__
 
 #include "kritis3m_application_config.h"
@@ -45,6 +43,7 @@ k_timeout_t
 #include "asl.h"
 #endif
 
+#include "linux_comp.h"
 #include "http_parser.h"
 
 #ifdef __cplusplus

--- a/http_lib/include/linux_comp.h
+++ b/http_lib/include/linux_comp.h
@@ -6,31 +6,26 @@ extern "C"
 {
 #endif
 
+
+/* foreward declaration of time structs */
 typedef struct timepoint timepoint;
+
 typedef struct duration duration;
 
-duration ms_toduration(int ms);
-int duration_toms(duration duration);
-
-timepoint timepoint_add_duration(timepoint tp, duration duration);
-duration get_differential_duration(timepoint reference, timepoint timepoint);
-duration get_remaining_duration_reference_now(timepoint timepoint);
-timepoint get_now();
-// reference to now
-timepoint get_timepoint_in(duration duration);
 
 #if defined(__ZEPHYR__)
 
 #include <zephyr/kernel.h>
+//#include <inttypes.h>
 
 struct duration
 {
-        int timespan;
+        k_timeout_t timespan;
 };
 // Struct definitions
 struct timepoint
 {
-        int time;
+        k_timepoint_t time;
 };
 
 
@@ -50,7 +45,20 @@ struct timepoint
 
 #endif /* __ZEPHYR__ */
 
-// future time
+
+/* method declaration */
+
+duration ms_to_duration(int ms);
+
+int duration_to_ms(duration duration);
+
+timepoint timepoint_add_duration(timepoint tp, duration duration);
+
+duration get_remaining_duration_reference_now(timepoint timepoint);
+
+timepoint get_timepoint_in(duration duration);
+
+
 
 #ifdef __cplusplus
 }

--- a/http_lib/include/linux_comp.h
+++ b/http_lib/include/linux_comp.h
@@ -21,17 +21,23 @@ timepoint get_timepoint_in(duration duration);
 
 #if defined(__ZEPHYR__)
 
+#include <zephyr/kernel.h>
+
 struct duration
 {
-        int a;
+        int timespan;
 };
 // Struct definitions
 struct timepoint
 {
-        int b;
+        int time;
 };
-#else
+
+
+#else /* __ZEPHYR__ */
+
 #include <time.h>
+
 struct duration
 {
         struct timespec timespan;
@@ -42,7 +48,7 @@ struct timepoint
         struct timespec time;
 };
 
-#endif
+#endif /* __ZEPHYR__ */
 
 // future time
 

--- a/http_lib/src/http_client.c
+++ b/http_lib/src/http_client.c
@@ -22,11 +22,11 @@
 /********************************************
  * 			    ZEPHYR				  	    *
  * *****************************************/
-#if defined(__ZEPYHR__)
+#if defined(__ZEPHYR__)
 #include <zephyr/kernel.h>
-#else
+
+#else /* __ZEPHYR__ */
 #include <limits.h>
-// #include <linux/kernel.h> // for offset of and other kernel utilities
 #include <stdio.h>
 
 #define CONTAINER_OF(ptr, type, member)                                                            \
@@ -36,11 +36,7 @@
         })
 #define snprintk snprintf
 
-#endif
-
-// #include <netinet/in.h>
-// #include <poll.h>
-// #include <sys/socket.h>
+#endif /* __ZEPHYR__ */
 
 #include "http_client.h"
 #include "logging.h"

--- a/http_lib/src/http_client.c
+++ b/http_lib/src/http_client.c
@@ -139,7 +139,7 @@ static int sendall(int sock, const void* buf, size_t len, timepoint timepoint)
                 {
                         struct pollfd pfd;
                         int pollres;
-                        int req_timeout_ms = duration_toms(
+                        int req_timeout_ms = duration_to_ms(
                                 get_remaining_duration_reference_now(timepoint));
                         if (req_timeout_ms < 0)
                                 return -ETIMEDOUT;
@@ -587,7 +587,8 @@ static int https_wait_data(int sock, asl_session* session, struct http_request* 
 {
         int total_received = 0;
         size_t offset = 0;
-        int received, ret;
+        int received; 
+        int ret;
         struct pollfd fds[1];
         int nfds = 1;
 
@@ -596,7 +597,7 @@ static int https_wait_data(int sock, asl_session* session, struct http_request* 
 
         do
         {
-                int remaining_duration = duration_toms(get_remaining_duration_reference_now(endtimeout));
+                int remaining_duration = duration_to_ms(get_remaining_duration_reference_now(endtimeout));
                 if (remaining_duration < 0)
                 {
                         goto error;
@@ -721,7 +722,7 @@ static int http_wait_data(int sock, struct http_request* req, const timepoint re
 
         do
         {
-                int reamaining_time_ms = duration_toms(
+                int reamaining_time_ms = duration_to_ms(
                         get_remaining_duration_reference_now(req_end_timepoint));
 
                 ret = poll(fds, nfds, reamaining_time_ms);

--- a/management_service/src/http_service.c
+++ b/management_service/src/http_service.c
@@ -102,7 +102,7 @@ int init_http_service(Kritis3mManagemntConfiguration* config,
         // Perform address lookup for management endpoint
         if (address_lookup_client(config->server_endpoint_addr.address,
                                   config->server_endpoint_addr.port,
-                                  (struct addrinfo**) &http_service.con.mgmt_sockaddr) != 0)
+                                  (struct addrinfo**) &http_service.con.mgmt_sockaddr, AF_UNSPEC) != 0)
         {
                 goto cleanup;
         }
@@ -116,7 +116,7 @@ int init_http_service(Kritis3mManagemntConfiguration* config,
 #ifdef PKI_READY
         if (address_lookup_client(config->identity.server_endpoint_addr.address,
                                   config->identity.server_endpoint_addr.port,
-                                  (struct addrinfo**) &http_service.mgmt_pki.mgmt_sockaddr) != 0)
+                                  (struct addrinfo**) &http_service.mgmt_pki.mgmt_sockaddr, AF_UNSPEC) != 0)
         {
                 goto cleanup;
         }

--- a/management_service/src/http_service.c
+++ b/management_service/src/http_service.c
@@ -365,7 +365,7 @@ int send_statusto_server(t_http_get_cb response_callback,
         req.payload = payload;
         req.payload_len = payload_size;
 
-        duration timeout = ms_toduration(14 * 1000);
+        duration timeout = ms_to_duration(14 * 1000);
 
         ret = startup_connection(&http_service.con);
         if (ret < 0)
@@ -489,7 +489,7 @@ int initial_call_controller(t_http_get_cb response_callback)
         req.port = port;
         req.recv_buf = (uint8_t*) response_buffer;
         req.recv_buf_len = sizeof(response_buffer);
-        duration timeout = ms_toduration(14 * 1000);
+        duration timeout = ms_to_duration(14 * 1000);
 
         ret = startup_connection(&http_service.con);
         if (ret < 0)

--- a/network_tester/src/network_tester.c
+++ b/network_tester/src/network_tester.c
@@ -195,7 +195,7 @@ static int network_init(network_tester* tester)
          * results in a noop. */
         if (address_lookup_client(tester->config->target_ip,
                                   tester->config->target_port,
-                                  &tester->target_addr) < 0)
+                                  &tester->target_addr, AF_UNSPEC) < 0)
                 ERROR_OUT("Error looking up target IP address");
 
         tester->current_target = tester->target_addr;

--- a/quest_lib/src/kritis3m_http_request.c
+++ b/quest_lib/src/kritis3m_http_request.c
@@ -28,11 +28,15 @@ static void manage_request_error(struct http_get_response* response, cJSON* data
         {
                 LOG_ERROR("invalid request resumption!\n");
                 response->error_code = HTTP_ERR;
+                response->bytes_received = 0;
+                response->buffer_frag_start = NULL;
         }
         else
         {
                 LOG_ERROR("error occured: %s\n", error_msg->valuestring);
                 response->error_code = HTTP_ERR;
+                response->bytes_received = 0;
+                response->buffer_frag_start = NULL;
         }
 
 #if (TMP_KEY)
@@ -129,13 +133,6 @@ static void http_get_cb(struct http_response* rsp, enum http_final_call final_da
                 }
 
                 cJSON_Delete(data);
-
-                return;
-
-        error_occured:
-                http_request_status->error_code = HTTP_ERR;
-                http_request_status->bytes_received = 0;
-                http_request_status->buffer_frag_start = NULL;
                 return;
         }
 }

--- a/quest_lib/src/quest.c
+++ b/quest_lib/src/quest.c
@@ -134,7 +134,7 @@ HOST_CON_ERR:
 enum kritis3m_status_info quest_send_request(struct quest_configuration* config)
 {
         enum kritis3m_status_info status = E_OK;
-        duration timeout = ms_toduration(TIMEOUT_DURATION);
+        duration timeout = ms_to_duration(TIMEOUT_DURATION);
 
         status = http_client_req(config->connection_info.socket_fd,
                                  config->request,

--- a/quest_lib/src/quest.c
+++ b/quest_lib/src/quest.c
@@ -10,7 +10,6 @@ LOG_MODULE_CREATE(quest_lib);
 static enum kritis3m_status_info establish_host_connection(struct quest_configuration* config)
 {
         int status;
-        int sock = -1;
         struct addrinfo* bind_addr = NULL;
 
         /* Look-up IP address from hostname and hostport */

--- a/quest_lib/src/quest.c
+++ b/quest_lib/src/quest.c
@@ -61,7 +61,7 @@ static enum kritis3m_status_info establish_host_connection(struct quest_configur
         /* Look-up IP address from hostname and hostport */
         status = address_lookup_client(config->connection_info.hostname,
                                        (uint16_t) strtol(config->connection_info.hostport, NULL, 10),
-                                       &bind_addr);
+                                       &bind_addr, AF_INET);
         if (status != 0)
         {
                 LOG_ERROR("error looking up server IP address, error code %d", status);

--- a/tcp_client_stdin_bridge/src/tcp_client_stdin_bridge.c
+++ b/tcp_client_stdin_bridge/src/tcp_client_stdin_bridge.c
@@ -405,7 +405,7 @@ int tcp_client_stdin_bridge_run(tcp_client_stdin_bridge_config const* config)
          * results in a noop. */
         if (address_lookup_client(config->target_ip_address,
                                   config->target_port,
-                                  &client_stdin_bridge.target_addr) < 0)
+                                  &client_stdin_bridge.target_addr, AF_UNSPEC) < 0)
                 ERROR_OUT("Error looking up target IP address");
 
         /* Create the TCP socket for the outgoing connection */

--- a/tls_proxy/src/proxy_backend.c
+++ b/tls_proxy/src/proxy_backend.c
@@ -213,7 +213,7 @@ static int add_new_proxy(enum tls_proxy_direction direction, proxy_config const*
         /* Create the TCP sockets for the incoming connections (IPv4 and IPv6).
          * Do a DNS lookup to make sure we have an IP address. If we already have an IP, this
          * results in a noop. */
-        if (address_lookup_server(config->own_ip_address, config->listening_port, &bind_addr) < 0)
+        if (address_lookup_server(config->own_ip_address, config->listening_port, &bind_addr, AF_UNSPEC) < 0)
                 ERROR_OUT_EX(proxy->log_module, "Error looking up bind IP address");
 
         /* Iterate over the linked-list of results */
@@ -247,7 +247,7 @@ static int add_new_proxy(enum tls_proxy_direction direction, proxy_config const*
 
         /* Do a DNS lookup to make sure we have an IP address. If we already have an IP, this
          * results in a noop. */
-        if (address_lookup_client(config->target_ip_address, config->target_port, &proxy->target_addr) < 0)
+        if (address_lookup_client(config->target_ip_address, config->target_port, &proxy->target_addr, AF_UNSPEC) < 0)
                 ERROR_OUT_EX(proxy->log_module, "Error looking up target IP address");
 
         LOG_DEBUG_EX(proxy->log_module,


### PR DESCRIPTION
Pull request to integrate changes in the quest_lib and http_lib enabeling functionality on zephyr and linux simultaneously into the main branch of the repository. Changes to the kritis3m_applications are listed as follows:

### Key Changes:
- **[ INTERFACE CHANGE ]** **address_lookup_server()** and **address_lookup_client()** now have a new parameter *family* specifying the expected IP address family. 
  Possible family types are: **AF_INET**, **AF_INET6** and **AF_UNSPEC**. Adjusted all calls of this function accordingly.
- major changes to the _linux_comp.c_ implementation to enable zephyr http functionality.
- minor changes  in  _quest.c_ **establish_host_connection()** function to work with zephyr zsock_addrin type
- new converter function in _quest.c_ to translate between socket address types.
---

### Modifications:
- added **build/** folder to the _.gitignore_ file