### PR TITLE
HTTPS Support for secure (and encrypted) key requests to the QKD line

### DIFF
--- a/http_lib/include/linux_comp.h
+++ b/http_lib/include/linux_comp.h
@@ -9,7 +9,6 @@ extern "C"
 
 /* foreward declaration of time structs */
 typedef struct timepoint timepoint;
-
 typedef struct duration duration;
 
 
@@ -22,7 +21,6 @@ struct duration
 {
         k_timeout_t timespan;
 };
-// Struct definitions
 struct timepoint
 {
         k_timepoint_t time;
@@ -37,7 +35,6 @@ struct duration
 {
         struct timespec timespan;
 };
-// Struct definitions
 struct timepoint
 {
         struct timespec time;
@@ -46,19 +43,31 @@ struct timepoint
 #endif /* __ZEPHYR__ */
 
 
-/* method declaration */
-
+/// @brief converts integer value for miliseconds to duration datatype.
+/// @param ms duration parameter specifying the length of the time duration.
+/// @return returns duration value of the respective duration.
 duration ms_to_duration(int ms);
 
+/// @brief converts duration value for miliseconds to integer datatype.
+/// @param duration duration parameter specifying the length of the duration.
+/// @return returns integer value of the respective duration.
 int duration_to_ms(duration duration);
 
+/// @brief add time duration on top of a specific timepoint. 
+/// @param tp timepoint value specifying the time. 
+/// @param duration time duration to be added on top of the timepoint. 
+/// @return returns resulting timepoint including the duration value. 
 timepoint timepoint_add_duration(timepoint tp, duration duration);
 
+/// @brief get the duration value to a specific time point. 
+/// @param timepoint Timepoint value used to calculate the time delate.
+/// @return returns the time delta as value of type duration (can be a negative value). 
 duration get_remaining_duration_reference_now(timepoint timepoint);
 
+/// @brief get timepoint, when the time duration is reached.
+/// @param duration time duration value added ontop of the current timepoint.
+/// @return returns future timepoint value when the duration is reached. 
 timepoint get_timepoint_in(duration duration);
-
-
 
 #ifdef __cplusplus
 }

--- a/http_lib/src/http_client.c
+++ b/http_lib/src/http_client.c
@@ -1403,7 +1403,6 @@ int https_client_req(int sock, asl_session* session, struct http_request* req, d
         /**
          * @todo error handling
          */
-        // total_recv = http_wait_data(sock, req, req_end_timepoint);
         if (total_recv < 0)
         {
                 LOG_DEBUG("Wait data failure (%d)", total_recv);

--- a/http_lib/src/linux_comp.c
+++ b/http_lib/src/linux_comp.c
@@ -2,12 +2,17 @@
 
 #if defined(__ZEPHYR__)
 
-// Convert milliseconds to duration
+/*------------------------------- public functions -------------------------------*/
 duration ms_to_duration(int ms)
 {
         duration dur;
-        dur.timespan = K_MSEC(ms);              // Convert milliseconds to seconds
+        dur.timespan = K_MSEC(ms);
         return dur;
+}
+
+int duration_to_ms(duration dur)
+{
+        return k_ticks_to_ms_floor32(dur.timespan.ticks);
 }
 
 timepoint get_timepoint_in(duration duration)
@@ -18,21 +23,12 @@ timepoint get_timepoint_in(duration duration)
         return timepoint_add_duration(now, duration);
 }
 
-// Convert duration to milliseconds
-int duration_to_ms(duration dur)
-{
-        return k_ticks_to_ms_floor32(dur.timespan.ticks);
-}
-
-// Add a duration to a timepoint
 timepoint timepoint_add_duration(timepoint tp, duration dur)
 {
         tp.time = sys_timepoint_calc(dur.timespan);
         return tp;
 }
 
-
-// Get the remaining duration from now to a future timepoint
 duration get_remaining_duration_reference_now(timepoint tp)
 {
         duration dur;
@@ -48,53 +44,21 @@ duration get_remaining_duration_reference_now(timepoint tp)
 #include <sys/time.h>
 #include <time.h>
 
-// Convert milliseconds to duration
-duration ms_to_duration(int ms)
-{
-        duration dur;
-        dur.timespan.tv_sec = ms / 1000;              // Convert milliseconds to seconds
-        dur.timespan.tv_nsec = (ms % 1000) * 1000000; // Convert remaining milliseconds to nanoseconds
-        return dur;
-}
+/*------------------------------ private functions -------------------------------*/
 
+/// @brief get the current timepoint value.
+/// @return returns timpoint value.
 static timepoint get_now()
 {
         timepoint now;
-        clock_gettime(CLOCK_MONOTONIC, &now.time); // Get the current time
+        clock_gettime(CLOCK_MONOTONIC, &now.time);
         return now;
 }
 
-timepoint get_timepoint_in(duration duration)
-{
-        timepoint now = get_now();
-        return timepoint_add_duration(now, duration);
-}
-
-// Convert duration to milliseconds
-int duration_to_ms(duration dur)
-{
-        return (dur.timespan.tv_sec * 1000) + (dur.timespan.tv_nsec / 1000000);
-}
-
-// Add a duration to a timepoint
-timepoint timepoint_add_duration(timepoint tp, duration dur)
-{
-        // Add seconds
-        tp.time.tv_sec += dur.timespan.tv_sec;
-        // Add nanoseconds
-        tp.time.tv_nsec += dur.timespan.tv_nsec;
-
-        // Normalize nanoseconds if they overflow
-        if (tp.time.tv_nsec >= 1000000000)
-        {
-                tp.time.tv_sec += tp.time.tv_nsec / 1000000000;
-                tp.time.tv_nsec %= 1000000000;
-        }
-
-        return tp;
-}
-
-// Get the difference between two timepoints as a duration
+/// @brief get the difference between two timpoints.
+/// @param ref reference timepoint value used to calculate difference.
+/// @param tp second timepoint value subtracted from the reference timepoint.
+/// @return returns the difference between the two timepoints as duration (can be negative).
 static duration get_differential_duration(timepoint ref, timepoint tp)
 {
         duration diff;
@@ -113,7 +77,43 @@ static duration get_differential_duration(timepoint ref, timepoint tp)
         return diff;
 }
 
-// Get the remaining duration from now to a future timepoint
+/*------------------------------- public functions -------------------------------*/
+duration ms_to_duration(int ms)
+{
+        duration dur;
+        dur.timespan.tv_sec = ms / 1000;              // Convert milliseconds to seconds
+        dur.timespan.tv_nsec = (ms % 1000) * 1000000; // Convert remaining milliseconds to nanoseconds
+        return dur;
+}
+
+int duration_to_ms(duration dur)
+{
+        return (dur.timespan.tv_sec * 1000) + (dur.timespan.tv_nsec / 1000000);
+}
+
+timepoint get_timepoint_in(duration duration)
+{
+        timepoint now = get_now();
+        return timepoint_add_duration(now, duration);
+}
+
+timepoint timepoint_add_duration(timepoint tp, duration dur)
+{
+        // Add seconds
+        tp.time.tv_sec += dur.timespan.tv_sec;
+        // Add nanoseconds
+        tp.time.tv_nsec += dur.timespan.tv_nsec;
+
+        // Normalize nanoseconds if they overflow
+        if (tp.time.tv_nsec >= 1000000000)
+        {
+                tp.time.tv_sec += tp.time.tv_nsec / 1000000000;
+                tp.time.tv_nsec %= 1000000000;
+        }
+
+        return tp;
+}
+
 duration get_remaining_duration_reference_now(timepoint tp)
 {
         timepoint now;
@@ -121,4 +121,5 @@ duration get_remaining_duration_reference_now(timepoint tp)
 
         return get_differential_duration(now, tp); // Get the remaining duration
 }
+
 #endif

--- a/quest_lib/CMakeLists.txt
+++ b/quest_lib/CMakeLists.txt
@@ -25,8 +25,3 @@ target_link_libraries(kritis3m-quest PUBLIC kritis3m-http-libs)
 
 # Link against the kritis3m_applications_common
 target_link_libraries(kritis3m-quest PUBLIC kritis3m_applications_common)
-
-# Copy the certificates and keys into the build folder
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/certs/chain.pem DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/certs/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/certs/privateKey.pem DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/certs/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/certs/root.pem DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/certs/)

--- a/quest_lib/CMakeLists.txt
+++ b/quest_lib/CMakeLists.txt
@@ -25,3 +25,8 @@ target_link_libraries(kritis3m-quest PUBLIC kritis3m-http-libs)
 
 # Link against the kritis3m_applications_common
 target_link_libraries(kritis3m-quest PUBLIC kritis3m_applications_common)
+
+# Copy the certificates and keys into the build folder
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/certs/chain.pem DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/certs/)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/certs/privateKey.pem DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/certs/)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/certs/root.pem DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/certs/)

--- a/quest_lib/CMakeLists.txt
+++ b/quest_lib/CMakeLists.txt
@@ -7,19 +7,11 @@ project(QUEST C)
 # Set the version of the library
 set(PROJECT_VERSION 1.0.0)
 
-# In case the QKD line does not operate correctly the library can inject a temporary key
-option(FALLBACK_PSK "Inject a hardcoded PSK into the http_cb" OFF)
-
 # Add the library sources
 add_library(kritis3m-quest STATIC
   src/kritis3m_http_request.c 
   src/quest.c
 )
-
-# set compile definition of FALLBACK_PSK option if activated
-if (FALLBACK_PSK)
-    target_compile_definitions(kritis3m-quest PRIVATE TMP_KEY)
-endif()
 
 # Include public headers for `library`
 target_include_directories(kritis3m-quest

--- a/quest_lib/include/quest.h
+++ b/quest_lib/include/quest.h
@@ -57,7 +57,7 @@ struct quest_configuration
 
         } connection_info;
 
-        struct 
+        struct
         {
                 /* Use HTTPS connection instead of HTTP */
                 bool enable_secure_con;
@@ -67,7 +67,7 @@ struct quest_configuration
 
                 /* OPTIONAL parameter for HTTPS communication */
                 asl_session* tls_session;
-        
+
         } security_param;
 
         /* Specify which type of HTTP-GET message shall be sent */

--- a/quest_lib/include/quest.h
+++ b/quest_lib/include/quest.h
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "asl.h"
 #include "http_client.h"
 #include "http_method.h"
 #include "kritis3m_http_request.h"
@@ -29,6 +30,7 @@ enum kritis3m_status_info
         WOLFSSL_ERR = -5,
         ADDR_ERR = -6,
         CON_ERR = -7,
+        ASL_ERR = -8,
 };
 
 struct quest_configuration
@@ -48,12 +50,25 @@ struct quest_configuration
                 char* hostport;
 
                 /* IP_v4 address used for host connection*/
-                struct sockaddr_in IP_v4;
+                struct addrinfo* IP_v4;
 
                 /* IP_v4 string for readability */
                 char IP_str[INET6_ADDRSTRLEN];
 
         } connection_info;
+
+        struct 
+        {
+                /* Use HTTPS connection instead of HTTP */
+                bool enable_secure_con;
+
+                /* OPTIONAL parameter for asl client endpoint */
+                asl_endpoint* client_endpoint;
+
+                /* OPTIONAL parameter for HTTPS communication */
+                asl_session* tls_session;
+        
+        } security_param;
 
         /* Specify which type of HTTP-GET message shall be sent */
         enum http_get_request_type request_type;

--- a/quest_lib/src/kritis3m_http_request.c
+++ b/quest_lib/src/kritis3m_http_request.c
@@ -3,24 +3,6 @@
 
 LOG_MODULE_CREATE(kritis3m_http_request);
 
-#if (TMP_KEY)
-/// @brief This function serves as temporary fix to insert key material into the TLS application.
-///        As soon, as the QKD line problem is resolved, this code must be removed from the
-///        library implementation!
-/// @param response http_response object containing message information and returns the key info
-///        to the sender of the http_get call.
-static void insert_temporary_key(struct http_get_response* response)
-{
-        char temp_key[] = "1111 1111 1111 1111 1111 1111 11\0";
-        char temp_key_ID[] = "2222 2222 2222 2222 2222 2222 22\0";
-
-        memcpy(response->key_info->key, &temp_key, strlen(temp_key));
-        memcpy(response->key_info->key_ID, &temp_key_ID, strlen(temp_key_ID));
-
-        response->key_info->key_len = strlen(temp_key);
-}
-#endif
-
 static void manage_request_error(struct http_get_response* response, cJSON* data)
 {
         cJSON* error_msg = cJSON_GetObjectItemCaseSensitive(data, "message");
@@ -38,11 +20,6 @@ static void manage_request_error(struct http_get_response* response, cJSON* data
                 response->bytes_received = 0;
                 response->buffer_frag_start = NULL;
         }
-
-#if (TMP_KEY)
-        /* this call is a fix, which can be deactivated as CMAKE option, once the QKD line is fixed */
-        insert_temporary_key(response);
-#endif
 }
 
 static void derive_key_info(struct http_get_response* response, cJSON* data)

--- a/quest_lib/src/quest.c
+++ b/quest_lib/src/quest.c
@@ -9,7 +9,7 @@ LOG_MODULE_CREATE(quest_lib);
 
 /*------------------------------ private functions -------------------------------*/
 
-/// @brief Using the conection parameter, this function establishes the connection to the 
+/// @brief Using the conection parameter, this function establishes the connection to the
 ///        host and creates the tls session and handshake, if enable_secure_con is true.
 /// @param config quest configuration containing the connection_info and security_params.
 /// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
@@ -25,8 +25,9 @@ static enum kritis3m_status_info establish_host_connection(struct quest_configur
                 goto SOCKET_CON_ERR;
         }
 
-        if (connect(config->connection_info.socket_fd,(struct sockaddr*) config->connection_info.IP_v4->ai_addr, 
-                config->connection_info.IP_v4->ai_addrlen) < 0)
+        if (connect(config->connection_info.socket_fd,
+                    (struct sockaddr*) config->connection_info.IP_v4->ai_addr,
+                    config->connection_info.IP_v4->ai_addrlen) < 0)
         {
                 LOG_ERROR("connection failed, error code: %d\n", errno);
                 status = SOCKET_ERR;
@@ -34,17 +35,19 @@ static enum kritis3m_status_info establish_host_connection(struct quest_configur
         }
 
         /* if enable_secure_con is true we need to perform a TLS handshake */
-        if(config->security_param.enable_secure_con)
+        if (config->security_param.enable_secure_con)
         {
-                config->security_param.tls_session = asl_create_session(config->security_param.client_endpoint, config->connection_info.socket_fd);
-                if(config->security_param.tls_session == NULL)
+                config->security_param
+                        .tls_session = asl_create_session(config->security_param.client_endpoint,
+                                                          config->connection_info.socket_fd);
+                if (config->security_param.tls_session == NULL)
                 {
                         LOG_ERROR("failed to establish tls session.\n");
                         status = ASL_ERR;
                         goto SOCKET_CON_ERR;
                 }
 
-                if(asl_handshake(config->security_param.tls_session) < 0)
+                if (asl_handshake(config->security_param.tls_session) < 0)
                 {
                         LOG_ERROR("tls handshake unsuccessful.\n");
                         status = ASL_ERR;
@@ -56,7 +59,7 @@ SOCKET_CON_ERR:
         return status;
 }
 
-/// @brief To establish a connection to the QKD line we need a DNS resolve call to get the IP 
+/// @brief To establish a connection to the QKD line we need a DNS resolve call to get the IP
 ///        address of the QKD key management server and subsequent port socket preparation.
 /// @param config quest_configuration containing the connection_info parameters.
 /// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
@@ -70,7 +73,8 @@ static enum kritis3m_status_info derive_connection_parameter(struct quest_config
         /* Look-up IP address from hostname and hostport */
         status = address_lookup_client(config->connection_info.hostname,
                                        (uint16_t) strtol(config->connection_info.hostport, NULL, 10),
-                                       &config->connection_info.IP_v4, AF_INET);
+                                       &config->connection_info.IP_v4,
+                                       AF_INET);
         if (status != 0)
         {
                 LOG_ERROR("error looking up server IP address, error code %d", status);
@@ -79,9 +83,11 @@ static enum kritis3m_status_info derive_connection_parameter(struct quest_config
 
         /* temporary fix to connect to mock-server */
         config->connection_info.hostname = "im-lfd-qkd-bob.othr.de";
-       
+
         /* Convert the IP from socket_addr_in to string */
-        inet_ntop(AF_INET, config->connection_info.IP_v4, config->connection_info.IP_str,
+        inet_ntop(AF_INET,
+                  config->connection_info.IP_v4,
+                  config->connection_info.IP_str,
                   sizeof(config->connection_info.IP_str));
 
         LOG_INFO("IP address for %s: %s:%s\n",
@@ -121,11 +127,22 @@ enum kritis3m_status_info quest_deinit(struct quest_configuration* config)
         if (config == NULL)
                 return E_OK;
 
-        if(config->security_param.enable_secure_con)
+        if (config->connection_info.socket_fd > 0)
         {
+                /* close connection to the QKD line */
+                close(config->connection_info.socket_fd);
+        }
+
+        if (config->security_param.enable_secure_con)
+        {
+                /* close and free asl_session */
                 asl_close_session(config->security_param.tls_session);
-                asl_free_endpoint(config->security_param.client_endpoint);
-                asl_cleanup();
+                asl_free_session(config->security_param.tls_session);
+                config->security_param.tls_session = NULL;
+
+                /* we only close the session here, as we potentially need
+                 * the endpoint again for future handshakes during the
+                 * runtime of this application. */
         }
 
         if (config->request != NULL)
@@ -155,7 +172,7 @@ enum kritis3m_status_info quest_init(struct quest_configuration* config)
                 goto HOST_CON_ERR;
 
         status = establish_host_connection(config);
-        if(status < E_OK)
+        if (status < E_OK)
                 goto HOST_CON_ERR;
 
         config->request = allocate_http_request();
@@ -180,17 +197,22 @@ enum kritis3m_status_info quest_send_request(struct quest_configuration* config)
 {
         enum kritis3m_status_info status = E_OK;
         duration timeout = ms_to_duration(TIMEOUT_DURATION);
-        
+
         /* if enable_secure_con is true, we use HTTPS */
-        if(config->security_param.enable_secure_con)
+        if (config->security_param.enable_secure_con)
         {
-                status = https_client_req(config->connection_info.socket_fd, config->security_param.tls_session, 
-                        config->request, timeout, config->response);
+                status = https_client_req(config->connection_info.socket_fd,
+                                          config->security_param.tls_session,
+                                          config->request,
+                                          timeout,
+                                          config->response);
         }
         else /* otherwise we use standard HTTP */
         {
                 status = http_client_req(config->connection_info.socket_fd,
-                        config->request, timeout, config->response);
+                                         config->request,
+                                         timeout,
+                                         config->response);
         }
 
         if (status < 0)

--- a/quest_lib/src/quest.c
+++ b/quest_lib/src/quest.c
@@ -1,4 +1,5 @@
 #include "quest.h"
+#include "file_io.h"
 #include "logging.h"
 #include "networking.h"
 
@@ -8,93 +9,129 @@ LOG_MODULE_CREATE(quest_lib);
 
 /*------------------------------ private functions -------------------------------*/
 
-#if defined(__ZEPHYR__)
-/// @brief As zephyr operates with it's own type of address information (zsock_addrinfo),
-///        we need to convert the address variable derived from the getaddressinfo()
-///        call into a variable of type sockaddr_in, to ensure correct behaviour later on.
-/// @param zaddr_info zephyr socket address info struct previously passed to the
-///                   getaddressinfo() function.
-/// @param addr pointer to the destination sockaddr_in variable used later on.
-/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
-static enum kritis3m_status_info convert_addrinfo_to_sockaddr_in(struct zsock_addrinfo* zaddr_info,
-                                                                 struct sockaddr_in* addr)
-{
-        if (zaddr_info == NULL || addr == NULL)
-        {
-                LOG_ERROR("passed argument was NULL!");
-                return E_NOT_OK;
-        }
-
-        // We expect the resolved address to be of type IPv4.
-        // TODO: integrate IPv6 support here.
-        if (zaddr_info->ai_family == AF_INET)
-        {
-                struct sockaddr_in* addr_in = (struct sockaddr_in*) zaddr_info->ai_addr;
-                *addr = *addr_in;
-        }
-        else
-        {
-                LOG_WARN("resolved IP address was not of type IPv4.");
-                return ADDR_ERR;
-        }
-
-        return E_OK;
-}
-#endif
-
-/// @brief To initialize the quest lib we establish a connection to the QKD line. This
-///        requires a DNS resolve call to get the IP address of the QKD server and subsequent
-///        socket preparation and connection establishment.
-/// @param config quest_configuration containing the connection_info parameters.
+/// @brief Using the conection parameter, this function establishes the connection to the 
+///        host and creates the tls session and handshake, if enable_secure_con is true.
+/// @param config quest configuration containing the connection_info and security_params.
 /// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
 static enum kritis3m_status_info establish_host_connection(struct quest_configuration* config)
 {
+        int status = E_OK;
+
+        config->connection_info.socket_fd = create_client_socket(AF_INET);
+        if (config->connection_info.socket_fd < 0)
+        {
+                LOG_ERROR("connection failed, error code: %d\n", errno);
+                status = SOCKET_ERR;
+                goto SOCKET_CON_ERR;
+        }
+
+        if (connect(config->connection_info.socket_fd,(struct sockaddr*) config->connection_info.IP_v4->ai_addr, 
+                config->connection_info.IP_v4->ai_addrlen) < 0)
+        {
+                LOG_ERROR("connection failed, error code: %d\n", errno);
+                status = SOCKET_ERR;
+                goto SOCKET_CON_ERR;
+        }
+
+        /* if enable_secure_con is true we need to perform a TLS handshake */
+        if(config->security_param.enable_secure_con)
+        {
+                config->security_param.tls_session = asl_create_session(config->security_param.client_endpoint, config->connection_info.socket_fd);
+                if(config->security_param.tls_session == NULL)
+                {
+                        LOG_ERROR("failed to establish tls session.\n");
+                        status = ASL_ERR;
+                        goto SOCKET_CON_ERR;
+                }
+
+                if(asl_handshake(config->security_param.tls_session) < 0)
+                {
+                        LOG_ERROR("tls handshake unsuccessful.\n");
+                        status = ASL_ERR;
+                        goto SOCKET_CON_ERR;
+                }
+        }
+
+SOCKET_CON_ERR:
+        return status;
+}
+
+/// @brief To establish a connection to the QKD line we need a DNS resolve call to get the IP 
+///        address of the QKD key management server and subsequent port socket preparation.
+/// @param config quest_configuration containing the connection_info parameters.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+static enum kritis3m_status_info derive_connection_parameter(struct quest_configuration* config)
+{
         int status;
 
-#if defined(__ZEPHYR__)
-        /* zephyr's socket addrinfo variable to store resolved IP address */
-        struct zsock_addrinfo* bind_addr = NULL;
-#else
-        /* addrinfo* variable to store resolved IP address */
-        struct addrinfo* bind_addr = NULL;
-#endif
+        /* temporary fix to connect to mock-server */
+        config->connection_info.hostname = "127.0.0.2";
+
         /* Look-up IP address from hostname and hostport */
         status = address_lookup_client(config->connection_info.hostname,
                                        (uint16_t) strtol(config->connection_info.hostport, NULL, 10),
-                                       &bind_addr, AF_INET);
+                                       &config->connection_info.IP_v4, AF_INET);
         if (status != 0)
         {
                 LOG_ERROR("error looking up server IP address, error code %d", status);
                 return ADDR_ERR;
         }
 
-#if defined(__ZEPHYR__)
-        /* Convert zephyr's socket address info to socket address_in */
-        status = convert_addrinfo_to_sockaddr_in(bind_addr, &config->connection_info.IP_v4);
-        if (status != E_OK)
-        {
-                LOG_ERROR("error occured during address conversion.");
-                return ADDR_ERR;
-        }
-#else
-        /* Copy binary version of the IP address */
-        memcpy(&config->connection_info.IP_v4, &bind_addr->ai_addr, sizeof(&bind_addr->ai_addr));
-#endif
-
+        /* temporary fix to connect to mock-server */
+        config->connection_info.hostname = "im-lfd-qkd-bob.othr.de";
+       
         /* Convert the IP from socket_addr_in to string */
-        void* addr = &(config->connection_info.IP_v4.sin_addr);
-        inet_ntop(bind_addr->ai_family,
-                  addr,
-                  config->connection_info.IP_str,
+        inet_ntop(AF_INET, config->connection_info.IP_v4, config->connection_info.IP_str,
                   sizeof(config->connection_info.IP_str));
 
-        LOG_INFO("IP address for %s: %s\n",
+        LOG_INFO("IP address for %s: %s:%s\n",
                  config->connection_info.hostname,
-                 config->connection_info.IP_str);
+                 config->connection_info.IP_str,
+                 config->connection_info.hostport);
 
-        /* Convert host port from string to unsigned integer */
-        config->connection_info.IP_v4.sin_port = htons(
-                strtoul(config->connection_info.hostport, NULL, 10));
+        return E_OK;
+}
+
+/// @brief If the connection to the QKD line key management interface is secured via HTTPS,
+///        we need to establish the Agile Security Library (ASL) to verify the server 
+///        certificate and encrypt the communication with the server.
+/// @param config quest_configuration containing the fields for the security_params populated
+///        in this function.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+static enum kritis3m_status_info initialize_asl_library(struct quest_configuration* config)
+{
+        asl_configuration asl_config = asl_default_config();
+        if(asl_init(&asl_config) < 0)
+                return ASL_ERR;
+        
+        certificates certs = get_empty_certificates();
+        asl_endpoint_configuration endpoint_config = asl_default_endpoint_config();
+        
+        /* set certificate and key paths */
+        certs.root_path        = "../build/_deps/kritis3m_applications-build/quest_lib/certs/root.pem";
+        certs.certificate_path = "../build/_deps/kritis3m_applications-build/quest_lib/certs/chain.pem";
+        certs.private_key_path = "../build/_deps/kritis3m_applications-build/quest_lib/certs/privateKey.pem";
+        
+        /*read certificates into buffer */
+        if(read_certificates(&certs) != 0)
+                return ASL_ERR;
+        
+        /* assign cert chain buffer and size to the asl_endpoint_config */
+        endpoint_config.device_certificate_chain.buffer = certs.chain_buffer;
+        endpoint_config.device_certificate_chain.size = certs.chain_buffer_size;
+
+        /* assign private key buffer and size to the asl_endpoint_config */
+        endpoint_config.private_key.buffer = certs.key_buffer;
+        endpoint_config.private_key.size = certs.key_buffer_size;
+
+        /* assign root cert buffer and size to the asl_endpoint_config */
+        endpoint_config.root_certificate.buffer = certs.root_buffer;
+        endpoint_config.root_certificate.size = certs.root_buffer_size;
+
+        /* set mutual authentication to false */
+        endpoint_config.mutual_authentication = false;
+
+        config->security_param.client_endpoint = asl_setup_client_endpoint(&endpoint_config);         
 
         return E_OK;
 }
@@ -107,6 +144,10 @@ struct quest_configuration* quest_default_config(void)
         default_config = malloc(sizeof(struct quest_configuration));
 
         default_config->verbose = false;
+
+        default_config->security_param.enable_secure_con = true;
+        default_config->security_param.client_endpoint = NULL;
+        default_config->security_param.tls_session = NULL;
 
         default_config->connection_info.hostname = "im-lfd-qkd-bob.othr.de";
         default_config->connection_info.hostport = "9120";
@@ -123,6 +164,13 @@ enum kritis3m_status_info quest_deinit(struct quest_configuration* config)
 {
         if (config == NULL)
                 return E_OK;
+
+        if(config->security_param.enable_secure_con)
+        {
+                asl_close_session(config->security_param.tls_session);
+                asl_free_endpoint(config->security_param.client_endpoint);
+                asl_cleanup();
+        }
 
         if (config->request != NULL)
         {
@@ -146,29 +194,20 @@ enum kritis3m_status_info quest_init(struct quest_configuration* config)
 {
         enum kritis3m_status_info status = E_OK;
 
-        status = establish_host_connection(config);
+        if(config->security_param.enable_secure_con)
+        {
+                status = initialize_asl_library(config);
+                if(status < E_OK)
+                        goto HOST_CON_ERR;
+        }
+
+        status = derive_connection_parameter(config);
         if (status < E_OK)
-        {
                 goto HOST_CON_ERR;
-        }
 
-        config->connection_info.socket_fd = create_client_socket(AF_INET);
-        if (config->connection_info.socket_fd < 0)
-        {
-                LOG_ERROR("connection failed, error code: %d\n", errno);
-                status = SOCKET_ERR;
-                goto SOCKET_CON_ERR;
-        }
-
-        if (connect(config->connection_info.socket_fd,
-                    (struct sockaddr*) &config->connection_info.IP_v4,
-                    sizeof(config->connection_info.IP_v4)) < 0)
-        {
-
-                LOG_ERROR("connection failed, error code: %d\n", errno);
-                status = SOCKET_ERR;
-                goto SOCKET_CON_ERR;
-        }
+        status = establish_host_connection(config);
+        if(status < E_OK)
+                goto HOST_CON_ERR;
 
         config->request = allocate_http_request();
 
@@ -181,8 +220,6 @@ enum kritis3m_status_info quest_init(struct quest_configuration* config)
                               config->connection_info.hostname,
                               config->connection_info.hostport,
                               config->key_ID);
-
-SOCKET_CON_ERR:
         return status;
 
 HOST_CON_ERR:
@@ -194,11 +231,19 @@ enum kritis3m_status_info quest_send_request(struct quest_configuration* config)
 {
         enum kritis3m_status_info status = E_OK;
         duration timeout = ms_to_duration(TIMEOUT_DURATION);
+        
+        /* if enable_secure_con is true, we use HTTPS */
+        if(config->security_param.enable_secure_con)
+        {
+                status = https_client_req(config->connection_info.socket_fd, config->security_param.tls_session, 
+                        config->request, timeout, config->response);
+        }
+        else /* otherwise we use standard HTTP */
+        {
+                status = http_client_req(config->connection_info.socket_fd,
+                        config->request, timeout, config->response);
+        }
 
-        status = http_client_req(config->connection_info.socket_fd,
-                                 config->request,
-                                 timeout,
-                                 config->response);
         if (status < 0)
         {
                 LOG_ERROR("failed to send HTTP-GET request, error code: %d\n", status);


### PR DESCRIPTION
Pull request to integrate changes in the **quest_lib** and http_lib enabling HTTPS functionality on zephyr and Linux. Changes to the kritis3m_applications are listed as follows:

### Key Changes:
- implemented **asl tls session** functionality to secure the key requests in the quest_lib.
- added new **security_parameter** struct to the **quest_configuration** struct.
- refactored functions: _establish_host_connection()_ and _derive_connection_parameter()_ to plattform independant solution.

---

### Modifications:
- removed zephyr specific address translation function. 
- removed fallback PSK functionality, as this feature is no longer used.
- reworked _linux_comp.c_ and _linux_comp.h_ implementation to increase usability.