### PR TITLE
Refactored quest_lib structure to match kritis3m_asl

### DIFF
--- a/quest_lib/CMakeLists.txt
+++ b/quest_lib/CMakeLists.txt
@@ -10,14 +10,20 @@ set(PROJECT_VERSION 1.0.0)
 # Add the library sources
 add_library(kritis3m-quest STATIC
   src/kritis3m_http_request.c 
+  src/quest_endpoint.c
+  src/quest_transaction.c
   src/quest.c
 )
 
 # Include public headers for `library`
-target_include_directories(kritis3m-quest
-    PUBLIC
+target_include_directories(kritis3m-quest PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include/kritis3m-http-libs>
+)
+
+# Private headers
+target_include_directories(kritis3m-quest PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/private_include
 )
 
 # Link against the kritis3m-http-libs library

--- a/quest_lib/include/quest.h
+++ b/quest_lib/include/quest.h
@@ -11,11 +11,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "asl.h"
 #include "http_client.h"
 #include "http_method.h"
 #include "kritis3m_http_request.h"
 #include "networking.h"
+
+typedef struct quest_configuration quest_configuration;
+typedef struct quest_transaction quest_transaction;
+typedef struct quest_endpoint quest_endpoint;
 
 enum kritis3m_status_info
 {
@@ -31,6 +34,7 @@ enum kritis3m_status_info
         ADDR_ERR = -6,
         CON_ERR = -7,
         ASL_ERR = -8,
+        PARAM_ERR = -9,
 };
 
 struct quest_configuration
@@ -40,20 +44,11 @@ struct quest_configuration
 
         struct
         {
-                /* File-descriptor for the socket connection*/
-                int socket_fd;
-
                 /* Hostname of the QKD Server REST-API */
                 char* hostname;
 
                 /* Hostport of the QKD Server */
                 char* hostport;
-
-                /* IP_v4 address used for host connection*/
-                struct addrinfo* IP_v4;
-
-                /* IP_v4 string for readability */
-                char IP_str[INET6_ADDRSTRLEN];
 
         } connection_info;
 
@@ -62,51 +57,74 @@ struct quest_configuration
                 /* Use HTTPS connection instead of HTTP */
                 bool enable_secure_con;
 
-                /* OPTIONAL parameter for asl client endpoint */
+                /* ASL Endpoint used for secure communiction with the QKD line */
                 asl_endpoint* client_endpoint;
 
-                /* OPTIONAL parameter for HTTPS communication */
-                asl_session* tls_session;
-
         } security_param;
-
-        /* Specify which type of HTTP-GET message shall be sent */
-        enum http_get_request_type request_type;
-
-        /* HTTP-GET Request struct reference */
-        struct http_request* request;
-
-        /* HTTP-GET Response struct reference */
-        struct http_get_response* response;
-
-        /* OPTIONAL parameter for HTTP-GET WITH KEY ID */
-        char key_ID[33];
 };
 
-/// @brief generates a config for the quest library usage and populates it with default values.
-/// @return returns a refernce to the config struct object.
-struct quest_configuration* quest_default_config(void);
+/*------------------------------ quest configuration ------------------------------*/
 
-/// @brief after the exchange of http messages, the config musst be deallocated again. This function
-///        frees allocated memeory in the quest_configuration struct.
-/// @param config reference to the config used for the http-get key requests.
-/// @return returns E_OK if the intialization executed successful. Otherwise returns a negative
-///         error-code and generates a report in the log.
-enum kritis3m_status_info quest_deinit(struct quest_configuration* config);
+/// @brief Starting point of the QUEST lib usage. Returns the initial object of the
+///        quest_configuration struct with the default values set.
+/// @return returns a refernce to the allocated quest_configuration object or NULL, if an error occured.
+quest_configuration* quest_default_config(void);
 
-/// @brief initializes the http connection to the QKD server and populates the associated
-///        http-get request and response objects.
-/// @param config requires a quest_config reference parameter, as derived from the quest_default_config()
-///               function. The parameters of the config can be adapted according to the use-case.
-/// @return returns E_OK if the intialization executed successful. Otherwise returns a negative
-///         error-code and generates a report in the log.
-enum kritis3m_status_info quest_init(struct quest_configuration* config);
+/// @brief Frees the allocated quest_configuration.
+/// @param config reference to the configuration, which shall be freed.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+enum kritis3m_status_info quest_deinit(quest_configuration* config);
 
-/// @brief sends the http-get request to the QKD server.
-/// @param config requires a quest_config referemce parameter, as derived from the quest_default_config()
-///               function. The parameters of the config can be adapted according to the use-case.
-/// @return returns E_OK if the intialization executed successful. Otherwise returns a negative
-///         error-code and generates a report in the log.
-enum kritis3m_status_info quest_send_request(struct quest_configuration* config);
+/*--------------------------------- quest endpoint --------------------------------*/
+
+/// @brief Derives a QUEST libary endpoint based on the quest_confiquration parameter.
+/// @param config reference to the quest_configuration, which specifies the hostname,
+///               port and security state.
+/// @return returns reference to the allocated quest_endpoint object or NULL, if an error occured.
+quest_endpoint* quest_setup_endpoint(quest_configuration* config);
+
+/// @brief Frees the allocates quest_endpoint.
+/// @param endpoint reference to the endpoint, which shall be freed.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+enum kritis3m_status_info quest_free_endpoint(quest_endpoint* endpoint);
+
+/*------------------------------- quest transaction -------------------------------*/
+
+/// @brief Derives a transaction based on the quest_endpoint parameters and the additional
+///        function paramters.
+/// @param endpoint reference to the quest_endpoint containing the connection and security
+///                 information.
+/// @param req_type specifies the request type. Currently supported: HTTP_KEY_NO_ID,
+///                 HTTP_KEY_WITH_ID and HTTP_STATUS.
+/// @param identity if HTTP_KEY_WITH_ID is requested, the key identifier must be referenced here.
+/// @return returns a refernce to the allocated quest_transaction object or NULL, if an error occured.
+quest_transaction* quest_setup_transaction(quest_endpoint* endpoint,
+                                           enum http_get_request_type req_type,
+                                           char* identity);
+
+/// @brief Executes the configured transaction by establishing a connection to the QKD KMS and
+///        sending the HTTP(S)-GET request. The response is then written to the internal response
+///        parameter.
+/// @param qkd_transaction reference to the quest_transaction, which shall be executed.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+enum kritis3m_status_info quest_execute_transaction(quest_transaction* qkd_transaction);
+
+/// @brief Following the execution of a quest_transaction, the HTTP(S) response is written to
+///        the response field of the quest_transaction. This function returns the field to the
+///        user.
+/// @param transaction reference to the executed quest_transaction.
+/// @return returns reference to the http_get_response received from the QKD KMS.
+struct http_get_response* quest_get_transaction_response(quest_transaction* transaction);
+
+/// @brief Closes the connection to the QKD line, but does not clear the endpoint parameters.
+/// @param transaction reference to the quest_transaction, which contains the connection parameter
+///                    of the active connection to the QKD line.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+enum kritis3m_status_info quest_close_transaction(quest_transaction* transaction);
+
+/// @brief Frees the allocated quest_transaction.
+/// @param transaction reference to the quest_transaction, which should be freed.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+enum kritis3m_status_info quest_free_transaction(quest_transaction* transaction);
 
 #endif /* QUEST_LIB_H */

--- a/quest_lib/readme.md
+++ b/quest_lib/readme.md
@@ -1,0 +1,79 @@
+
+/***********************************************************************************/
+/*              Quantum-Key Exchange Server Transaction (QUEST) library            */
+/***********************************************************************************/
+
+The QUEST library is used to request information from a Quantum Key Distribution 
+(QKD) Key Management System (KMS). Among these information it is possible to re-
+quest the latest generated key using HTTP_KEY_NO_ID in the request_type, a specific 
+key by using HTTP_KEY_WITH_ID and a key_ID passed to the quest_transction or request 
+the current status of the QKD line by specifying HTTP_STATUS in the request_type.
+
+┌──────────────────────────┐
+│quest_configuration       │
+├──────────────────────────┤
+│+ verbose : bool          │
+│+ enable_secure_con : bool│
+│__                        │ <---- quest_default_config()
+│connection_info:          │
+│+ hostname : char*        │
+│+ hostport : char*        │
+└──────────────────────────┘
+              |
+              | quest_setup_endpoint()
+              v
+┌────────────────────────────────┐
+│quest_endpoint                  │
+├────────────────────────────────┤
+│+ verbose : bool                │
+│__                              │
+│connection_info:                │
+│+ socket_fd : int               │
+│+ hostname : char*              │
+│+ hostport : char*              │
+│+ IP_v4 : struct addrinfo*      │
+│+ IP_str : char[]               │
+│__                              │
+│security_param:                 │
+│+ enable_secure_con : bool      │
+│+ client_endpoint : asl_endpoint│
+└────────────────────────────────┘
+              |
+              | quest_setup_transaction()
+              v
+┌───────────────────────────────────────────┐
+│quest_transaction                          │
+├───────────────────────────────────────────┤
+│+ endpoint : quest_endpoint*               │
+│__                                         │
+│security_param:                            │
+│+ enable_secure_con : bool                 │
+│+ tls_session : asl_session*               │
+│__                                         │
+│+ request_type : enum http_get_request_type│
+│+ request_: http_request*                  │
+│+ response : http_get_response*            │
+│+ key_ID : char[]                          │
+└───────────────────────────────────────────┘
+
+As displayed in the diagram above, the QUEST library consists of three entities:
+
+Initially the user can generate a quest_configuration by calling the function 
+quest_default_config(). Subsequently the quest_configuration can be adjusted to the 
+by specifying the desired hostname and hostport, as well as activating the secure 
+connection and verbose flag. 
+
+Using this configuration, the function quest_setup_endpoint() derives a connection 
+endpoint, which contains further communication and security parameter. This endpoint 
+can be active for multiple requests to the same QKD line and further contains the 
+asl_endpoint containing the set of certificates for the HTTPS connection, if 
+enable_secure_con is set to true.
+
+Using the quest_endpoint parameters, the user can setup key or status requests by 
+calling the function quest_setup_transaction(). This function starts the communi- 
+cation procedure to the QKD line by establishing a TCP connection and generating the 
+neccessary HTTP(S)-request and HTTP(S)-response objects.
+
+By calling the function quest_send_request() the transaction is executed and the re- 
+quest is sent to the QKD KMS. If everything is working correctly, the response object 
+then contains the requested information. 

--- a/quest_lib/src/private_include/quest_types.h
+++ b/quest_lib/src/private_include/quest_types.h
@@ -1,0 +1,72 @@
+#ifndef QUEST_TYPES_H
+#define QUEST_TYPES_H
+
+#include "asl.h"
+#include "kritis3m_http_request.h"
+#include "quest.h"
+
+/*------------------------------ private structures ------------------------------*/
+struct quest_transaction
+{
+        /* quest endpoint containing connection parameter */
+        quest_endpoint* endpoint;
+
+        struct
+        {
+                /* Use HTTPS connection instead of HTTP */
+                bool enable_secure_con;
+
+                /* OPTIONAL parameter for HTTPS communication */
+                asl_session* tls_session;
+
+        } security_param;
+
+        /* Specify which type of HTTP-GET message shall be sent */
+        enum http_get_request_type request_type;
+
+        /* HTTP-GET Request struct reference */
+        struct http_request* request;
+
+        /* HTTP-GET Response struct reference */
+        struct http_get_response* response;
+
+        /* OPTIONAL parameter for HTTP-GET WITH KEY ID */
+        char key_ID[33];
+};
+
+struct quest_endpoint
+{
+        /* Verbose flag to configure runtime information */
+        bool verbose;
+
+        struct
+        {
+                /* File-descriptor for the socket connection */
+                int socket_fd;
+
+                /* Hostname of the QKD Server REST-API */
+                char* hostname;
+
+                /* Hostport of the QKD Server */
+                char* hostport;
+
+                /* IP_v4 address used for host connection */
+                struct addrinfo* IP_v4;
+
+                /* IP_v4 string for log entries */
+                char IP_str[INET6_ADDRSTRLEN];
+
+        } connection_info;
+
+        struct
+        {
+                /* Use HTTPS connection instead of HTTP */
+                bool enable_secure_con;
+
+                /* OPTIONAL parameter for asl client endpoint */
+                asl_endpoint* client_endpoint;
+
+        } security_param;
+};
+
+#endif

--- a/quest_lib/src/quest.c
+++ b/quest_lib/src/quest.c
@@ -1,229 +1,35 @@
 #include "quest.h"
-#include "file_io.h"
-#include "logging.h"
-#include "networking.h"
-
-#define TIMEOUT_DURATION 5000
-
-LOG_MODULE_CREATE(quest_lib);
+#include "kritis3m_http_request.h"
 
 /*------------------------------ private functions -------------------------------*/
 
-/// @brief Using the conection parameter, this function establishes the connection to the
-///        host and creates the tls session and handshake, if enable_secure_con is true.
-/// @param config quest configuration containing the connection_info and security_params.
-/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
-static enum kritis3m_status_info establish_host_connection(struct quest_configuration* config)
-{
-        int status = E_OK;
-
-        config->connection_info.socket_fd = create_client_socket(AF_INET);
-        if (config->connection_info.socket_fd < 0)
-        {
-                LOG_ERROR("connection failed, error code: %d\n", errno);
-                status = SOCKET_ERR;
-                goto SOCKET_CON_ERR;
-        }
-
-        if (connect(config->connection_info.socket_fd,
-                    (struct sockaddr*) config->connection_info.IP_v4->ai_addr,
-                    config->connection_info.IP_v4->ai_addrlen) < 0)
-        {
-                LOG_ERROR("connection failed, error code: %d\n", errno);
-                status = SOCKET_ERR;
-                goto SOCKET_CON_ERR;
-        }
-
-        /* if enable_secure_con is true we need to perform a TLS handshake */
-        if (config->security_param.enable_secure_con)
-        {
-                config->security_param
-                        .tls_session = asl_create_session(config->security_param.client_endpoint,
-                                                          config->connection_info.socket_fd);
-                if (config->security_param.tls_session == NULL)
-                {
-                        LOG_ERROR("failed to establish tls session.\n");
-                        status = ASL_ERR;
-                        goto SOCKET_CON_ERR;
-                }
-
-                if (asl_handshake(config->security_param.tls_session) < 0)
-                {
-                        LOG_ERROR("tls handshake unsuccessful.\n");
-                        status = ASL_ERR;
-                        goto SOCKET_CON_ERR;
-                }
-        }
-
-SOCKET_CON_ERR:
-        return status;
-}
-
-/// @brief To establish a connection to the QKD line we need a DNS resolve call to get the IP
-///        address of the QKD key management server and subsequent port socket preparation.
-/// @param config quest_configuration containing the connection_info parameters.
-/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
-static enum kritis3m_status_info derive_connection_parameter(struct quest_configuration* config)
-{
-        int status;
-
-        /* temporary fix to connect to mock-server */
-        config->connection_info.hostname = "127.0.0.2";
-
-        /* Look-up IP address from hostname and hostport */
-        status = address_lookup_client(config->connection_info.hostname,
-                                       (uint16_t) strtol(config->connection_info.hostport, NULL, 10),
-                                       &config->connection_info.IP_v4,
-                                       AF_INET);
-        if (status != 0)
-        {
-                LOG_ERROR("error looking up server IP address, error code %d", status);
-                return ADDR_ERR;
-        }
-
-        /* temporary fix to connect to mock-server */
-        config->connection_info.hostname = "im-lfd-qkd-bob.othr.de";
-
-        /* Convert the IP from socket_addr_in to string */
-        inet_ntop(AF_INET,
-                  config->connection_info.IP_v4,
-                  config->connection_info.IP_str,
-                  sizeof(config->connection_info.IP_str));
-
-        LOG_INFO("IP address for %s: %s:%s\n",
-                 config->connection_info.hostname,
-                 config->connection_info.IP_str,
-                 config->connection_info.hostport);
-
-        return E_OK;
-}
-
 /*------------------------------- public functions -------------------------------*/
-struct quest_configuration* quest_default_config(void)
+quest_configuration* quest_default_config(void)
 {
-        struct quest_configuration* default_config;
-
+        quest_configuration* default_config;
         default_config = malloc(sizeof(struct quest_configuration));
+
+        if (default_config == NULL)
+                return NULL;
 
         default_config->verbose = false;
 
-        default_config->security_param.enable_secure_con = true;
-        default_config->security_param.client_endpoint = NULL;
-        default_config->security_param.tls_session = NULL;
-
         default_config->connection_info.hostname = "im-lfd-qkd-bob.othr.de";
         default_config->connection_info.hostport = "9120";
-        default_config->connection_info.socket_fd = -1;
 
-        default_config->request_type = HTTP_KEY_NO_ID;
-        default_config->request = NULL;
-        default_config->response = NULL;
+        default_config->security_param.enable_secure_con = false;
+        default_config->security_param.client_endpoint = NULL;
 
         return default_config;
 }
 
-enum kritis3m_status_info quest_deinit(struct quest_configuration* config)
+enum kritis3m_status_info quest_deinit(quest_configuration* config)
 {
         if (config == NULL)
                 return E_OK;
-
-        if (config->connection_info.socket_fd > 0)
-        {
-                /* close connection to the QKD line */
-                close(config->connection_info.socket_fd);
-        }
-
-        if (config->security_param.enable_secure_con)
-        {
-                /* close and free asl_session */
-                asl_close_session(config->security_param.tls_session);
-                asl_free_session(config->security_param.tls_session);
-                config->security_param.tls_session = NULL;
-
-                /* we only close the session here, as we potentially need
-                 * the endpoint again for future handshakes during the
-                 * runtime of this application. */
-        }
-
-        if (config->request != NULL)
-        {
-                /* free http-get resquest */
-                deinit_http_request(config->request, config->response->msg_type);
-        }
-
-        if (config->response != NULL)
-        {
-                /* free http-get response */
-                deinit_http_response(config->response);
-        }
 
         /* free quest configuration */
         free(config);
 
         return E_OK;
-}
-
-enum kritis3m_status_info quest_init(struct quest_configuration* config)
-{
-        enum kritis3m_status_info status = E_OK;
-
-        status = derive_connection_parameter(config);
-        if (status < E_OK)
-                goto HOST_CON_ERR;
-
-        status = establish_host_connection(config);
-        if (status < E_OK)
-                goto HOST_CON_ERR;
-
-        config->request = allocate_http_request();
-
-        config->response = allocate_http_response();
-
-        populate_http_response(config->response, config->request_type);
-
-        populate_http_request(config->request,
-                              config->response,
-                              config->connection_info.hostname,
-                              config->connection_info.hostport,
-                              config->key_ID);
-        return status;
-
-HOST_CON_ERR:
-        LOG_ERROR("error occured during execution, error code: %d\n", errno);
-        return QUEST_ERR;
-}
-
-enum kritis3m_status_info quest_send_request(struct quest_configuration* config)
-{
-        enum kritis3m_status_info status = E_OK;
-        duration timeout = ms_to_duration(TIMEOUT_DURATION);
-
-        /* if enable_secure_con is true, we use HTTPS */
-        if (config->security_param.enable_secure_con)
-        {
-                status = https_client_req(config->connection_info.socket_fd,
-                                          config->security_param.tls_session,
-                                          config->request,
-                                          timeout,
-                                          config->response);
-        }
-        else /* otherwise we use standard HTTP */
-        {
-                status = http_client_req(config->connection_info.socket_fd,
-                                         config->request,
-                                         timeout,
-                                         config->response);
-        }
-
-        if (status < 0)
-        {
-                LOG_ERROR("failed to send HTTP-GET request, error code: %d\n", status);
-                status = CON_ERR;
-        }
-        else
-        {
-                status = E_OK;
-        }
-
-        return status;
 }

--- a/quest_lib/src/quest_endpoint.c
+++ b/quest_lib/src/quest_endpoint.c
@@ -1,0 +1,133 @@
+#include "quest.h"
+#include "quest_types.h"
+
+#include "logging.h"
+#include "networking.h"
+
+LOG_MODULE_CREATE(quest_endpoint);
+
+/*------------------------------ private functions -------------------------------*/
+
+/// @brief Derives neccessary connection parameter based on the paramter passed in 
+///        the quest_configuration. 
+/// @param endpoint reference to the quest_endpoint, which contains the input paramter 
+///        and the reserved fields for the derivated parameter.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+static enum kritis3m_status_info derive_connection_parameter(quest_endpoint* endpoint)
+{
+        int status;
+
+        /* temporary fix to connect to mock-server */
+        endpoint->connection_info.hostname = "127.0.0.2";
+
+        /* Look-up IP address from hostname and hostport */
+        status = address_lookup_client(endpoint->connection_info.hostname,
+                                       (uint16_t) strtol(endpoint->connection_info.hostport, NULL, 10),
+                                       &endpoint->connection_info.IP_v4,
+                                       AF_INET);
+        if (status != 0)
+        {
+                LOG_ERROR("error looking up server IP address, error code %d", status);
+                return ADDR_ERR;
+        }
+
+        /* temporary fix to connect to mock-server */
+        endpoint->connection_info.hostname = "im-lfd-qkd-bob.othr.de";
+
+        /* Convert the IP from socket_addr_in to string */
+        inet_ntop(AF_INET,
+                  endpoint->connection_info.IP_v4,
+                  endpoint->connection_info.IP_str,
+                  sizeof(endpoint->connection_info.IP_str));
+
+        LOG_INFO("IP address for %s: %s:%s\n",
+                 endpoint->connection_info.hostname,
+                 endpoint->connection_info.IP_str,
+                 endpoint->connection_info.hostport);
+
+        return E_OK;
+}
+
+/// @brief Configures quest_endpoint based on the paramter contained in the quest_configuration.
+/// @param endpoint reference to the quest_endpoint, which shall be configured.
+/// @param config reference to the quest_configuration, which contains the configuration parameter.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+static enum kritis3m_status_info configure_endpoint(quest_endpoint* endpoint, quest_configuration* config)
+{
+        enum kritis3m_status_info status = E_OK;
+
+        if (config->connection_info.hostname == NULL)
+                goto INVALID_PARAM;
+
+        if (config->connection_info.hostport == NULL)
+                goto INVALID_PARAM;
+
+        endpoint->verbose = config->verbose;
+        endpoint->security_param.enable_secure_con = config->security_param.enable_secure_con;
+
+        if (endpoint->security_param.enable_secure_con)
+        {
+                endpoint->security_param.client_endpoint = config->security_param.client_endpoint;
+        }
+
+        endpoint->connection_info.hostname = config->connection_info.hostname;
+        endpoint->connection_info.hostport = config->connection_info.hostport;
+
+        return status;
+
+INVALID_PARAM:
+        status = PARAM_ERR;
+        return status;
+}
+
+/*------------------------------- public functions -------------------------------*/
+quest_endpoint* quest_setup_endpoint(quest_configuration* config)
+{
+        enum kritis3m_status_info status;
+        quest_endpoint* endpoint;
+
+        endpoint = malloc(sizeof(struct quest_endpoint));
+        if (endpoint == NULL)
+        {
+                LOG_ERROR("error occured during quest endpoint allocation.");
+                return NULL;
+        }
+
+        status = configure_endpoint(endpoint, config);
+        if (status != E_OK)
+        {
+                LOG_ERROR("error occured during quest endpoint setup.");
+                goto ENDPOINT_ERR;
+        }
+
+        status = derive_connection_parameter(endpoint);
+        if (status != E_OK)
+        {
+                LOG_ERROR("error occured during connection parameter derivation.");
+                goto ENDPOINT_ERR;
+        }
+
+        return endpoint;
+
+ENDPOINT_ERR:
+        free(endpoint);
+        return NULL;
+}
+
+enum kritis3m_status_info quest_free_endpoint(quest_endpoint* endpoint)
+{
+        if (endpoint->connection_info.IP_v4 != NULL)
+        {
+                /* free derived IP address */
+                freeaddrinfo(endpoint->connection_info.IP_v4);
+        }
+
+        if (endpoint->security_param.enable_secure_con &&
+            (endpoint->security_param.client_endpoint != NULL))
+        {
+                /* free asl_endpoint for the connection to th QKD line */
+                asl_free_endpoint(endpoint->security_param.client_endpoint);
+        }
+
+        return E_OK;
+}

--- a/quest_lib/src/quest_transaction.c
+++ b/quest_lib/src/quest_transaction.c
@@ -1,0 +1,255 @@
+#include "quest.h"
+#include "quest_types.h"
+
+#include "asl.h"
+#include "file_io.h"
+#include "logging.h"
+#include "networking.h"
+
+LOG_MODULE_CREATE(quest_transaction);
+
+#define TIMEOUT_DURATION 5000
+
+/*------------------------------ private functions -------------------------------*/
+
+/// @brief establishes the TCP connection to the QKD KMS based on the derivated con-
+///        nection information from the quest_endpoint.
+/// @param qkd_transaction reference to the transaction, which contains the 
+///        quest_endpoint reference, as well as the associated connection information.
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
+static enum kritis3m_status_info establish_host_connection(quest_transaction* qkd_transaction)
+{
+        int status = E_OK;
+
+        qkd_transaction->endpoint->connection_info.socket_fd = create_client_socket(AF_INET);
+        if (qkd_transaction->endpoint->connection_info.socket_fd < 0)
+        {
+                LOG_ERROR("connection failed, error code: %d\n", errno);
+                status = SOCKET_ERR;
+                goto SOCKET_CON_ERR;
+        }
+
+        if (connect(qkd_transaction->endpoint->connection_info.socket_fd,
+                    (struct sockaddr*) qkd_transaction->endpoint->connection_info.IP_v4->ai_addr,
+                    qkd_transaction->endpoint->connection_info.IP_v4->ai_addrlen) < 0)
+        {
+                LOG_ERROR("connection failed, error code: %d\n", errno);
+                status = SOCKET_ERR;
+                goto SOCKET_CON_ERR;
+        }
+
+        /* if enable_secure_con is true we need to perform a TLS handshake */
+        if (qkd_transaction->security_param.enable_secure_con)
+        {
+                qkd_transaction->security_param
+                        .tls_session = asl_create_session(qkd_transaction->endpoint->security_param.client_endpoint,
+                                                          qkd_transaction->endpoint->connection_info.socket_fd);
+
+                if (qkd_transaction->security_param.tls_session == NULL)
+                {
+                        LOG_ERROR("failed to establish tls session.\n");
+                        status = ASL_ERR;
+                        goto SOCKET_CON_ERR;
+                }
+
+                if (asl_handshake(qkd_transaction->security_param.tls_session) < 0)
+                {
+                        LOG_ERROR("tls handshake unsuccessful.\n");
+                        status = ASL_ERR;
+                        goto SOCKET_CON_ERR;
+                }
+        }
+
+SOCKET_CON_ERR:
+        return status;
+}
+
+/// @brief Configures the quest_transaction based on the paramters in the quest_endpoint
+///        and additional the function parameters.
+/// @param qkd_transaction reference to the quest_transaction, which shall be configured.
+/// @param endpoint reference to the quest_endpoint, which contains the configuration parameter.
+/// @param  req_type specifies the type of HTTP(S) request which shall be sent.
+/// @param identity OPTIONAL parameter, which must be set, if a key with a specific key identifier 
+///                 shall be requested (req_type must then be HTTP_KEY_WITH_ID).
+/// @return returns E_OK if working correctly, otherwise returns an error code less than zero. 
+static enum kritis3m_status_info configure_transaction(quest_transaction* qkd_transaction,
+                                                       quest_endpoint* endpoint,
+                                                       enum http_get_request_type req_type,
+                                                       char* identity)
+{
+        /* sanity check: required parameter */
+        if ((qkd_transaction == NULL) || (endpoint == NULL))
+                return PARAM_ERR;
+
+        /* sanity check: if a key should be requested with a
+         * specific ID, we need to make sure the ID is passed
+         * to the function. */
+        if ((req_type == HTTP_KEY_WITH_ID) && (identity == NULL))
+        {
+                LOG_ERROR("invalid parameter configuration. key identity was NULL.");
+                return PARAM_ERR;
+        }
+
+        /* set endpoint reference and security mode */
+        qkd_transaction->endpoint = endpoint;
+        qkd_transaction->security_param.enable_secure_con = endpoint->security_param.enable_secure_con;
+
+        /* set request type and key identity, if identity is passed to the function. */
+        qkd_transaction->request_type = req_type;
+        if (identity != NULL)
+        {
+                memcpy(qkd_transaction->key_ID, identity, strlen(identity));
+        }
+
+        return E_OK;
+}
+
+/*------------------------------- public functions -------------------------------*/
+quest_transaction* quest_setup_transaction(quest_endpoint* endpoint,
+                                           enum http_get_request_type req_type,
+                                           char* identity)
+{
+        enum kritis3m_status_info status = E_OK;
+        quest_transaction* qkd_transaction;
+
+        if (endpoint == NULL)
+        {
+                LOG_ERROR("invalid endpoint parameter.");
+                return NULL;
+        }
+
+        qkd_transaction = malloc(sizeof(struct quest_transaction));
+        if (qkd_transaction == NULL)
+        {
+                LOG_ERROR("error occured during quest transaction allocation.");
+                return NULL;
+        }
+
+        status = configure_transaction(qkd_transaction, endpoint, req_type, identity);
+        if (status != E_OK)
+        {
+                free(qkd_transaction);
+                goto TRANSACTION_ERR;
+        }
+
+        qkd_transaction->request = allocate_http_request();
+
+        qkd_transaction->response = allocate_http_response();
+
+        if (qkd_transaction->request == NULL)
+                goto TRANSACTION_ERR;
+
+        if (qkd_transaction->response == NULL)
+        {
+                /* if response is NULL here, we know, that the request
+                 * allocation was successful, but the response allocation
+                 * was not. Therfore, we only need to free the request and
+                 * exit gracefully. */
+
+                free(qkd_transaction->request);
+                goto TRANSACTION_ERR;
+        }
+
+        populate_http_response(qkd_transaction->response, qkd_transaction->request_type);
+
+        populate_http_request(qkd_transaction->request,
+                              qkd_transaction->response,
+                              qkd_transaction->endpoint->connection_info.hostname,
+                              qkd_transaction->endpoint->connection_info.hostport,
+                              qkd_transaction->key_ID);
+
+        return qkd_transaction;
+
+TRANSACTION_ERR:
+        LOG_ERROR("error occured during quest transaction configuration");
+        return NULL;
+}
+
+struct http_get_response* quest_get_transaction_response(quest_transaction* transaction)
+{
+        if (transaction->response == NULL)
+                LOG_WARN("transaction response is currently NULL");
+
+        return transaction->response;
+}
+
+enum kritis3m_status_info quest_execute_transaction(quest_transaction* qkd_transaction)
+{
+        enum kritis3m_status_info status = E_OK;
+        duration timeout = ms_to_duration(TIMEOUT_DURATION);
+
+        /* open socket and connect to the QKD line */
+        status = establish_host_connection(qkd_transaction);
+        if (status < E_OK)
+        {
+                LOG_ERROR("establishing host connection was unsuccessful, error code %d\n", errno);
+                goto QKD_CON_ERR;
+        }
+
+        /* if enable_secure_con is true, we use HTTPS */
+        if (qkd_transaction->security_param.enable_secure_con)
+        {
+                status = https_client_req(qkd_transaction->endpoint->connection_info.socket_fd,
+                                          qkd_transaction->security_param.tls_session,
+                                          qkd_transaction->request,
+                                          timeout,
+                                          qkd_transaction->response);
+        }
+        else /* otherwise we use standard HTTP */
+        {
+                status = http_client_req(qkd_transaction->endpoint->connection_info.socket_fd,
+                                         qkd_transaction->request,
+                                         timeout,
+                                         qkd_transaction->response);
+        }
+
+        if (status < 0)
+        {
+                LOG_ERROR("failed to send HTTP-GET request, error code: %d\n", status);
+                status = CON_ERR;
+        }
+        else
+        {
+                status = E_OK;
+        }
+
+QKD_CON_ERR:
+        return status;
+}
+
+enum kritis3m_status_info quest_close_transaction(quest_transaction* qkd_transaction)
+{
+        if (qkd_transaction->endpoint->connection_info.socket_fd > 0)
+        {
+                close(qkd_transaction->endpoint->connection_info.socket_fd);
+                qkd_transaction->endpoint->connection_info.socket_fd = -1;
+        }
+
+        return E_OK;
+}
+
+enum kritis3m_status_info quest_free_transaction(quest_transaction* qkd_transaction)
+{
+
+        if (qkd_transaction->security_param.enable_secure_con &&
+            (qkd_transaction->security_param.tls_session != NULL))
+        {
+                /* close and free the asl_session */
+                asl_close_session(qkd_transaction->security_param.tls_session);
+                asl_free_session(qkd_transaction->security_param.tls_session);
+        }
+
+        if (qkd_transaction->request != NULL)
+        {
+                /* free http-get resquest */
+                deinit_http_request(qkd_transaction->request, qkd_transaction->response->msg_type);
+        }
+
+        if (qkd_transaction->response != NULL)
+        {
+                /* free http-get response */
+                deinit_http_response(qkd_transaction->response);
+        }
+
+        return E_OK;
+}


### PR DESCRIPTION
Pull request to integrate changes in the quest_lib regarding the component division of the quest entities:

### Key Changes:
- new `quest_endpoint`, which can be used for multiple transactions to the QKD key management system.
- new `quest_transaction`, which is used in a single key or status request to the QKD key management system.
- new readme.md file to explain the different components and the workflow with this library.

---

### Modifications:
- moved structures `quest_endpoint` and `quest_transaction` to the private include header `quest_types.h` to ensure correct usage and enforce component creation only through the setup functions.
- reduced `quest_configuration` struct to only contain the neccessary paramters to start using the quest_lib.