### PR TITLE
Fixed Implementation for Memory-Check and missing free() statement in quest_lib 

### DIFF
--- a/quest_lib/src/kritis3m_http_request.c
+++ b/quest_lib/src/kritis3m_http_request.c
@@ -203,6 +203,9 @@ static void populate_key_with_id_url(struct http_request* request, char* key_ID)
                 return;
         }
 
+        /* Initialize request url buffer with zero values */
+        memset((char*)request->url, 0, total_len);
+
         // Copy the base URL and concatenate the key
         strcpy((char*) request->url, base_url);
         strcat((char*) request->url, key_ID);

--- a/quest_lib/src/private_include/quest_types.h
+++ b/quest_lib/src/private_include/quest_types.h
@@ -5,6 +5,8 @@
 #include "kritis3m_http_request.h"
 #include "quest.h"
 
+#define KEY_ID_LEN 64
+
 /*------------------------------ private structures ------------------------------*/
 struct quest_transaction
 {
@@ -31,7 +33,7 @@ struct quest_transaction
         struct http_get_response* response;
 
         /* OPTIONAL parameter for HTTP-GET WITH KEY ID */
-        char key_ID[33];
+        char key_ID[KEY_ID_LEN];
 };
 
 struct quest_endpoint

--- a/quest_lib/src/quest_endpoint.c
+++ b/quest_lib/src/quest_endpoint.c
@@ -129,5 +129,8 @@ enum kritis3m_status_info quest_free_endpoint(quest_endpoint* endpoint)
                 asl_free_endpoint(endpoint->security_param.client_endpoint);
         }
 
+        if (endpoint != NULL)
+                free(endpoint);
+
         return E_OK;
 }

--- a/quest_lib/src/quest_endpoint.c
+++ b/quest_lib/src/quest_endpoint.c
@@ -18,7 +18,7 @@ static enum kritis3m_status_info derive_connection_parameter(quest_endpoint* end
         int status;
 
         /* temporary fix to connect to mock-server */
-        endpoint->connection_info.hostname = "127.0.0.2";
+        endpoint->connection_info.hostname = "192.168.0.1";
 
         /* Look-up IP address from hostname and hostport */
         status = address_lookup_client(endpoint->connection_info.hostname,

--- a/quest_lib/src/quest_transaction.c
+++ b/quest_lib/src/quest_transaction.c
@@ -254,5 +254,8 @@ enum kritis3m_status_info quest_free_transaction(quest_transaction* qkd_transact
                 deinit_http_response(qkd_transaction->response);
         }
 
+        if (qkd_transaction != NULL)
+                free(qkd_transaction);
+
         return E_OK;
 }

--- a/quest_lib/src/quest_transaction.c
+++ b/quest_lib/src/quest_transaction.c
@@ -125,6 +125,9 @@ quest_transaction* quest_setup_transaction(quest_endpoint* endpoint,
                 return NULL;
         }
 
+        /* Ensure all buffers of the transaction are zero */
+        memset(qkd_transaction, 0, sizeof(struct quest_transaction));
+
         status = configure_transaction(qkd_transaction, endpoint, req_type, identity);
         if (status != E_OK)
         {


### PR DESCRIPTION
Pull request to integrate changes in the quest_lib regarding the correct parsing of the psk identity and the deinit of the quest_transaction:

### Key Changes:
- 0 initialization of the quest_transaction object following the allocation in `quest_setup_transaction`
- new free() statement in `quest_free_transaction()` and `quest_free_endpoint`

---

### Minor Modifications:
- adjusted temporary fix (IP-address) to comply with the benchmarking setup
- declared static buffer length for key_id parameter in `KEY_ID_LEN` 
