### PR TITLE
Implementation of modular SAE_ID usage in kritis3m_applications

### DIFF
--- a/quest_lib/CMakeLists.txt
+++ b/quest_lib/CMakeLists.txt
@@ -10,6 +10,7 @@ set(PROJECT_VERSION 1.0.0)
 # Add the library sources
 add_library(kritis3m-quest STATIC
   src/kritis3m_http_request.c 
+  src/kritis3m_http_response.c
   src/quest_endpoint.c
   src/quest_transaction.c
   src/quest.c

--- a/quest_lib/include/kritis3m_http.h
+++ b/quest_lib/include/kritis3m_http.h
@@ -11,7 +11,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #define DEFAULT_BUFFER_LEN 3000
-#define QKD_INFO_MAX_LEN 50
+#define QKD_INFO_MAX_LEN 64
 
 enum http_status_type
 {
@@ -80,6 +80,7 @@ void populate_http_response(struct http_get_response* response,
                             enum http_get_request_type request_type);
 
 /// @brief allocates a reponse object for the http-get call.
+/// @return returns reference to the allocated object or NULL of no memory is available.
 struct http_get_response* allocate_http_response();
 
 /// @brief frees the http_get request struct. As this function only contains standard parameter,
@@ -97,14 +98,17 @@ void deinit_http_request(struct http_request* request, enum http_get_request_typ
 /// @param response reference to the http_get_response object allocated before.
 /// @param hostname hostname of the server, where the http_get call shall be sent.
 /// @param hostport hostport of the server, where the http_get call shall be sent.
+/// @param sae_ID secure application entity identifier used in the request url.
 /// @param key_ID OPTIONAL parameter, if a http_get request for a referenced key_ID is neccessary.
 void populate_http_request(struct http_request* request,
                            struct http_get_response* response,
                            char* hostname,
                            char* hostport,
+                           char* sae_ID,
                            char* key_ID);
 
 /// @brief allocates a request object for the http-get call.
+/// @return returns reference to the allocated object or NULL of no memory is available.
 struct http_request* allocate_http_request();
 
 #endif

--- a/quest_lib/include/quest.h
+++ b/quest_lib/include/quest.h
@@ -13,7 +13,7 @@
 
 #include "http_client.h"
 #include "http_method.h"
-#include "kritis3m_http_request.h"
+#include "kritis3m_http.h"
 #include "networking.h"
 
 typedef struct quest_configuration quest_configuration;
@@ -46,6 +46,9 @@ struct quest_configuration
         {
                 /* Hostname of the QKD Server REST-API */
                 char* hostname;
+
+                /* Identifier of the QKD endpoint SAE */
+                char* host_sae_ID;
 
                 /* Hostport of the QKD Server */
                 char* hostport;
@@ -83,6 +86,12 @@ enum kritis3m_status_info quest_deinit(quest_configuration* config);
 /// @return returns reference to the allocated quest_endpoint object or NULL, if an error occured.
 quest_endpoint* quest_setup_endpoint(quest_configuration* config);
 
+/// @brief Get the secure application entity identifier for the quest endpoint.
+/// @param endpoint reference to the quest_endpoint containing the connection and security
+///                 information.
+/// @return returns the sae_ID as a const char reference.
+enum kritis3m_status_info quest_get_own_sae_id(quest_endpoint* endpoint, char* dst_buf);
+
 /// @brief Frees the allocates quest_endpoint.
 /// @param endpoint reference to the endpoint, which shall be freed.
 /// @return returns E_OK if working correctly, otherwise returns an error code less than zero.
@@ -96,10 +105,12 @@ enum kritis3m_status_info quest_free_endpoint(quest_endpoint* endpoint);
 ///                 information.
 /// @param req_type specifies the request type. Currently supported: HTTP_KEY_NO_ID,
 ///                 HTTP_KEY_WITH_ID and HTTP_STATUS.
+/// @param sae_ID   secure application entity identifiert used in the request url.
 /// @param identity if HTTP_KEY_WITH_ID is requested, the key identifier must be referenced here.
 /// @return returns a refernce to the allocated quest_transaction object or NULL, if an error occured.
 quest_transaction* quest_setup_transaction(quest_endpoint* endpoint,
                                            enum http_get_request_type req_type,
+                                           char* sae_ID,
                                            char* identity);
 
 /// @brief Executes the configured transaction by establishing a connection to the QKD KMS and

--- a/quest_lib/src/kritis3m_http_response.c
+++ b/quest_lib/src/kritis3m_http_response.c
@@ -1,0 +1,71 @@
+#include "kritis3m_http.h"
+#include "logging.h"
+
+LOG_MODULE_CREATE(kritis3m_http_response);
+
+/*------------------------------- private functions -------------------------------*/
+
+/// @brief Allocate object to the qkd_key_info used for storage of the the qkd_key and key_ID.
+/// @return returns reference to the allocated object or NULL of no memory is available.
+static struct qkd_key_info* allocate_key_info()
+{
+        /* allocate key_info struct for http_get_respone */
+        struct qkd_key_info* key_info;
+        key_info = malloc(sizeof(struct qkd_key_info));
+        if (key_info == NULL)
+        {
+                LOG_ERROR("failed to allocate HTTP-GET response key_info parameter.\n");
+                goto ALLOC_ERR;
+        }
+
+        return key_info;
+
+ALLOC_ERR:
+        return NULL;
+}
+
+/*------------------------------- public functions -------------------------------*/
+struct http_get_response* allocate_http_response()
+{
+        /* allocate response struct for http get request */
+        struct http_get_response* response;
+        response = malloc(sizeof(struct http_get_response));
+        if (response == NULL)
+        {
+                LOG_ERROR("failed to allocate HTTP-GET response.\n");
+                goto ALLOC_ERR;
+        }
+
+        memset(response, 0, sizeof(struct http_get_response));
+
+        return response;
+
+ALLOC_ERR:
+        return NULL;
+}
+
+void populate_http_response(struct http_get_response* response, enum http_get_request_type request_type)
+{
+        response->buffer_frag_start = NULL;
+        response->buffer_len = DEFAULT_BUFFER_LEN;
+        response->bytes_received = 0;
+        response->error_code = 0;
+        response->msg_type = request_type;
+
+        response->key_info = allocate_key_info();
+}
+
+void deinit_http_response(struct http_get_response* response)
+{
+        if (response == NULL)
+                return;
+
+        if (response->key_info != NULL)
+        {
+                free(response->key_info);
+        }
+
+        free(response);
+
+        return;
+}

--- a/quest_lib/src/private_include/quest_types.h
+++ b/quest_lib/src/private_include/quest_types.h
@@ -2,7 +2,7 @@
 #define QUEST_TYPES_H
 
 #include "asl.h"
-#include "kritis3m_http_request.h"
+#include "kritis3m_http.h"
 #include "quest.h"
 
 #define KEY_ID_LEN 64
@@ -23,6 +23,17 @@ struct quest_transaction
 
         } security_param;
 
+        struct 
+        {
+                /* Secure Application Entity Identifier */
+                char* sae_ID;
+                
+                /* OPTIONAL parameter for HTTP-GET WITH KEY ID */
+                char key_ID[KEY_ID_LEN];
+        
+        } url_param;
+        
+
         /* Specify which type of HTTP-GET message shall be sent */
         enum http_get_request_type request_type;
 
@@ -31,9 +42,6 @@ struct quest_transaction
 
         /* HTTP-GET Response struct reference */
         struct http_get_response* response;
-
-        /* OPTIONAL parameter for HTTP-GET WITH KEY ID */
-        char key_ID[KEY_ID_LEN];
 };
 
 struct quest_endpoint
@@ -48,6 +56,9 @@ struct quest_endpoint
 
                 /* Hostname of the QKD Server REST-API */
                 char* hostname;
+
+                /* Identifier of the QKD endpoint SAE */
+                char* host_sae_ID;
 
                 /* Hostport of the QKD Server */
                 char* hostport;

--- a/quest_lib/src/quest.c
+++ b/quest_lib/src/quest.c
@@ -1,5 +1,5 @@
 #include "quest.h"
-#include "kritis3m_http_request.h"
+#include "kritis3m_http.h"
 
 /*------------------------------ private functions -------------------------------*/
 
@@ -15,6 +15,7 @@ quest_configuration* quest_default_config(void)
         default_config->verbose = false;
 
         default_config->connection_info.hostname = "im-lfd-qkd-bob.othr.de";
+        default_config->connection_info.host_sae_ID = "bob_sae_etsi_1";
         default_config->connection_info.hostport = "9120";
 
         default_config->security_param.enable_secure_con = false;

--- a/quest_lib/src/quest_endpoint.c
+++ b/quest_lib/src/quest_endpoint.c
@@ -72,6 +72,7 @@ static enum kritis3m_status_info configure_endpoint(quest_endpoint* endpoint, qu
 
         endpoint->connection_info.hostname = config->connection_info.hostname;
         endpoint->connection_info.hostport = config->connection_info.hostport;
+        endpoint->connection_info.host_sae_ID = config->connection_info.host_sae_ID;
 
         return status;
 
@@ -112,6 +113,16 @@ quest_endpoint* quest_setup_endpoint(quest_configuration* config)
 ENDPOINT_ERR:
         free(endpoint);
         return NULL;
+}
+
+enum kritis3m_status_info quest_get_own_sae_id(quest_endpoint* endpoint, char* dst_buf)
+{
+        if(endpoint->connection_info.host_sae_ID == NULL)
+                return PARAM_ERR;
+
+        /* value copy of the host_sae_id to the buffer */
+        strcpy(dst_buf, endpoint->connection_info.host_sae_ID);
+        return E_OK;
 }
 
 enum kritis3m_status_info quest_free_endpoint(quest_endpoint* endpoint)


### PR DESCRIPTION
To comply with the specifications in **ETSI GS QKD 014**, the `remote_sae_id` addressed in the HTTP_GET requests must be passed from the client to the server (Especially with regard to potential network topologies instead of a simple point-to-point connection).

### Key Changes
- removed individual URL assembly functions, as we no longer concatenate hardcoded URL-elements and pass the specific parts to the new generic function `assemble_url`
- new public function in `quest.h` to get own_sae_id form the associated entity: `quest_get_own_sae_id`
- new parameter in `quest_endpoint` to store host `sae_id`
- adjusted `quest_setup_transaction` and `populate_http_request` functions to use new sae_id parameter.

---

### Modifications
- renamed `kritis3m_http_request.h` into generic `kritis3m_http.h`
- split (kritis3m) http request and response implementation into separate files: `kritis3m_http_request.c` and `kritis3m_http_response.c`
- increased `QKD_INFO_MAX_LEN` (array length limits in key_info struct) from 50 to 64
- added zero initialization to the allocate functions of `http_request` and `http_get_response`